### PR TITLE
Allow view template to be HTML

### DIFF
--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -29,7 +29,7 @@ module RailsPDF
       logger.debug "RailsPDF ====="
 
       begin
-        input  = BetterTempfile.new("in.pug")
+        input  = BetterTempfile.new("in.html")
         output = BetterTempfile.new("out.pdf")
 
         input.write(content)

--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -30,7 +30,7 @@ module RailsPDF
       logger.debug "RailsPDF ====="
 
       begin
-        input  = BetterTempfile.new("in-#{File.basename(@file)}")
+        input  = BetterTempfile.new("in-#{File.basename(@file, ".erb")}")
         output = BetterTempfile.new("out.pdf")
 
         input.write(content)

--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -25,6 +25,7 @@ module RailsPDF
       content = view.render(params)
 
       logger.debug "RailsPDF ====="
+      logger.debug "RailsPDF filename: #{@file.basename(path)}"
       logger.debug "RailsPDF content:\n#{content}"
       logger.debug "RailsPDF ====="
 

--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -36,7 +36,7 @@ module RailsPDF
         input.write(content)
         input.flush
 
-        command = "#{RailsPDF.relaxed} #{input.path.to_s} #{output.path.to_s} --basedir / --build-once"
+        command = "#{RailsPDF.relaxed} #{input.path.to_s} #{output.path.to_s} --basedir / --build-once --no-sandbox"
 
         logger.debug "RailsPDF ===== #{command}"
 

--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -29,7 +29,7 @@ module RailsPDF
       logger.debug "RailsPDF ====="
 
       begin
-        input  = BetterTempfile.new("in.html")
+        input  = BetterTempfile.new("in-#{@file.basename(path)}")
         output = BetterTempfile.new("out.pdf")
 
         input.write(content)

--- a/lib/rails_pdf/renderer.rb
+++ b/lib/rails_pdf/renderer.rb
@@ -25,12 +25,12 @@ module RailsPDF
       content = view.render(params)
 
       logger.debug "RailsPDF ====="
-      logger.debug "RailsPDF filename: #{@file.basename(path)}"
+      logger.debug "RailsPDF filename: #{File.basename(@file)}"
       logger.debug "RailsPDF content:\n#{content}"
       logger.debug "RailsPDF ====="
 
       begin
-        input  = BetterTempfile.new("in-#{@file.basename(path)}")
+        input  = BetterTempfile.new("in-#{File.basename(@file)}")
         output = BetterTempfile.new("out.pdf")
 
         input.write(content)


### PR DESCRIPTION
Relaxed treats input based on file extension (.pug vs .html), but previous code always created a temporary file "in.pug"; this could lead to relaxed treating HTML code as PUG code, resulting in errors. The change retains the view template's file extension for the temporary file and removes ".erb" if present.